### PR TITLE
Add hedron compile commands

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -1,0 +1,8 @@
+load("@hedron_compile_commands//:refresh_compile_commands.bzl", "refresh_compile_commands")
+
+refresh_compile_commands(
+  name = "refresh_compile_commands",
+  targets = {
+    "//src/hello_world:hello-world.elf": "--platforms=@pico-sdk//bazel/platform:rp2040",
+  },
+)

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -15,3 +15,12 @@ python.toolchain(
 bazel_dep(name = "pw_toolchain", version = "0.1")
 
 bazel_dep(name = "pico-sdk", version = "0.0.1")
+
+# Hedron's Compile Commands Extractor for Bazel
+# https://github.com/hedronvision/bazel-compile-commands-extractor
+bazel_dep(name = "hedron_compile_commands", dev_dependency = True)
+git_override(
+    module_name = "hedron_compile_commands",
+    remote = "https://github.com/hedronvision/bazel-compile-commands-extractor.git",
+    commit = "5bcb0bd8a917b2b48fb5dc55818515f4be3b63ff",
+)


### PR DESCRIPTION
Hedron Compile Commands didn't like a `--ffreestanding` tag. Likely I could have done selective dependencies to remove the issue, but `pico-sdk` removed the flag and everything works. Moving on.